### PR TITLE
Add support for Leadfoot's `findDisplayed` method

### DIFF
--- a/lib/Recorder.js
+++ b/lib/Recorder.js
@@ -428,7 +428,6 @@
 						}
 					};
 
-					self._contentPort.send('setFindDisplayed', [ self.findDisplayed ]);
 					self._contentPort.send('setStrategy', [ self.strategy ]);
 				}
 			});
@@ -763,7 +762,6 @@
 			this.storage.setItem('intern.findDisplayed', value);
 			this.findDisplayed = value;
 			this._findCommand = value ? 'findDisplayedByXpath' : 'findByXpath';
-			this._contentPort.send('setFindDisplayed', [ value ]);
 		},
 
 		setHotkey: function (hotkeyId, hotkey) {

--- a/lib/Recorder.js
+++ b/lib/Recorder.js
@@ -217,6 +217,7 @@
 		this.storage = storage;
 		this.hotkeys = JSON.parse(storage.getItem('intern.hotkeys')) || this._getDefaultHotkeys();
 		this.strategy = storage.getItem('intern.strategy') || 'xpath';
+		this.findDisplayed = storage.getItem('intern.findDisplayed') || false;
 
 		this._initializeScript();
 		this._initializePort();
@@ -229,6 +230,10 @@
 
 		_currentModifiers: null,
 		_currentTest: null,
+
+		_findCommand: 'findByXpath',
+
+		findDisplayed: null,
 
 		hotkeys: null,
 
@@ -423,6 +428,7 @@
 						}
 					};
 
+					self._contentPort.send('setFindDisplayed', [ self.findDisplayed ]);
 					self._contentPort.send('setStrategy', [ self.strategy ]);
 				}
 			});
@@ -707,7 +713,7 @@
 				}
 
 				if (event.target) {
-					this._record('findByXpath', [ event.target ]);
+					this._record(this._findCommand, [ event.target ]);
 				}
 
 				this._lastTarget = event.target;
@@ -715,6 +721,7 @@
 		},
 
 		refreshUi: function () {
+			this._port.send('setFindDisplayed', [ this.findDisplayed ]);
 			this._port.send('setScript', [ this._script ]);
 			this._port.send('setRecording', [ this.recording ]);
 			this._port.send('setStrategy', [ this.strategy ]);
@@ -750,6 +757,13 @@
 			}, function () {
 				URL.revokeObjectURL(url);
 			});
+		},
+
+		setFindDisplayed: function (value) {
+			this.storage.setItem('intern.findDisplayed', value);
+			this.findDisplayed = value;
+			this._findCommand = value ? 'findDisplayedByXpath' : 'findByXpath';
+			this._contentPort.send('setFindDisplayed', [ value ]);
 		},
 
 		setHotkey: function (hotkeyId, hotkey) {

--- a/lib/Recorder.js
+++ b/lib/Recorder.js
@@ -244,7 +244,10 @@
 		_lastTargetFrame: null,
 		_lastTestId: 0,
 
+		// connects to an EventProxy instance representing the web page that the devtools are open for
 		_contentPort: null,
+
+		// connects to a RecorderProxy instance representing the "Intern" panel in Chrome devtools
 		_port: null,
 
 		recording: false,

--- a/lib/RecorderProxy.js
+++ b/lib/RecorderProxy.js
@@ -204,6 +204,17 @@
 			input.onchange = function (event) {
 				self.send('setStrategy', [ event.target.value ]);
 			};
+
+			input = document.getElementById('option-findDisplayed');
+
+			/* istanbul ignore if: the recorder is broken if this ever happens */
+			if (!input) {
+				throw new Error('Panel is missing input for option "findDisplayed"');
+			}
+
+			input.onchange = function (event) {
+				self.send('setFindDisplayed', [ event.target.checked ]);
+			};
 		},
 
 		_initializePort: function () {
@@ -263,6 +274,12 @@
 
 		send: function (method, args) {
 			this._port.postMessage({ method: method, args: args });
+		},
+
+		setFindDisplayed: function (value) {
+			if (this.contentWindow) {
+				this.contentWindow.document.getElementById('option-findDisplayed').checked = value;
+			}
 		},
 
 		setHotkey: function (id, hotkey) {

--- a/lib/panel.html
+++ b/lib/panel.html
@@ -101,6 +101,14 @@
 							<option value="text">Use text of element</option>
 						</select>
 					</div>
+
+					<div class="option">
+							<input type="checkbox" id="option-findDisplayed">
+							<label for="option-findDisplayed">
+								Wait for <a href="https://theintern.github.io/leadfoot/Command.html#isDisplayed" target="_blank">displayed</a> element
+								(use <a href="https://theintern.github.io/leadfoot/Command.html#findDisplayed" target="blank"><code>findDisplayed</code></a>)
+							</label>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"dojo": "2.0.0-alpha.6",
-		"intern": "3.0.0-rc.1"
+		"intern": "3.0.0-rc.3"
 	},
 	"bugs": "https://github.com/theintern/intern/issues",
 	"keywords": [ "javascript", "test", "unit", "testing", "ci", "continuous integration", "bdd", "tdd", "xunit", "istanbul", "chai", "dojo", "toolkit", "selenium", "sauce labs", "code coverage", "recorder", "functional", "webdriver" ],

--- a/tests/data/output/findDisplayed.txt
+++ b/tests/data/output/findDisplayed.txt
@@ -1,0 +1,11 @@
+define(function (require) {
+	var tdd = require('intern!tdd');
+	tdd.suite('recorder-generated suite', function () {
+		tdd.test('Test 1', function () {
+			return this.remote
+				.get('http://example.com')
+				.findDisplayedByXpath('target')
+					.moveMouseTo(12, 23);
+		});
+	});
+});

--- a/tests/unit/Recorder.js
+++ b/tests/unit/Recorder.js
@@ -650,7 +650,6 @@ define(function (require) {
 				recorder.toggleState();
 				recorder.setFindDisplayed(true);
 				assert.lengthOf(devToolsPort.postMessage.calls, 3);
-				assert.deepEqual(eventProxyPort.postMessage.calls, [ [ { method: 'setFindDisplayed', args: [ true ] } ] ]);
 
 				recorder.recordEvent(createEvent({ type: 'mousemove' }));
 				recorder.insertMouseMove();

--- a/tests/unit/RecorderProxy.js
+++ b/tests/unit/RecorderProxy.js
@@ -77,6 +77,9 @@ define(function (require) {
 
 				var strategy = window.document.getElementById('option-strategy');
 				assert.isFunction(strategy.onchange);
+
+				var findDisplayed = window.document.getElementById('option-findDisplayed');
+				assert.isFunction(findDisplayed.onchange);
 			},
 
 			'button communication': function () {
@@ -171,11 +174,23 @@ define(function (require) {
 				]);
 			},
 
+			'findDisplayed set': function () {
+				mock(recorderProxy, 'send');
+
+				recorderProxy.setScript('test');
+
+				window.document.getElementById('option-findDisplayed').onchange({ target: { checked: true } });
+				assert.deepEqual(recorderProxy.send.calls, [
+					[ 'setFindDisplayed', [ true ] ]
+				]);
+			},
+
 			'hidden panel': function () {
 				var inactiveRecorderProxy = new RecorderProxy(chrome, panel);
 				assert.doesNotThrow(function () {
 					inactiveRecorderProxy.setScript('test');
 					inactiveRecorderProxy.setStrategy('test');
+					inactiveRecorderProxy.setFindDisplayed(true);
 					inactiveRecorderProxy.setHotkey('insertCallback', { keyIdentifier: 'U+0045' });
 				}, 'Setting properties for the UI without an active panel should be a no-op');
 			},
@@ -186,6 +201,11 @@ define(function (require) {
 				assert.deepEqual(devToolsPort.postMessage.calls, [
 					[ { method: 'test', args: [ 'arg1', 'argN' ] } ]
 				]);
+			},
+
+			'#setFindDisplayed': function () {
+				recorderProxy.setFindDisplayed(true);
+				assert.strictEqual(window.document.getElementById('option-findDisplayed').checked, true);
 			},
 
 			'#setHotkey': {


### PR DESCRIPTION
Add an option in the devtools UI to use LeadFoot's `findDisplayed` method when finding elements
